### PR TITLE
Add ability to resize on percentage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 var Jimp = require("jimp");
 var through = require('through2');
-var gutil = require('gulp-util');
 var File = require('vinyl');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var resize = require('./resize.js');
 var Promise = require('bluebird');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jimp-resize",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Maniuplate images' size with few dependencies. Uses JIMP wrapped with gulp.",
   "keywords": [
     "images",
@@ -22,14 +22,15 @@
   "author": "Conner Wells https://github.com/CSKingMartin",
   "license": "MIT",
   "dependencies": {
-    "jimp": "^0.2.24",
-    "bluebird": "^3.4.1"
+    "bluebird": "^3.4.1",
+    "fancy-log": "^1.3.3",
+    "jimp": "^0.13.0",
+    "plugin-error": "^1.0.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "gulp": "^3.9.1",
-    "gulp-util": "^3.0.7",
-    "mocha": "^2.5.3",
-    "through2": "^2.0.1"
+    "chai": "^4.2.0",
+    "gulp": "^4.0.2",
+    "mocha": "^8.0.1",
+    "through2": "^3.0.1"
   }
 }

--- a/resize.js
+++ b/resize.js
@@ -7,6 +7,8 @@ const PLUGIN_NAME = "gulp-jimp-resize";
 function goGoGadgetImageResize (file, opt) {
 	
 	var path = file.path;
+	var base = "";
+	var cwd = "";
 	
 	var suffix = "";
 	
@@ -14,10 +16,16 @@ function goGoGadgetImageResize (file, opt) {
 	
 	var extension = path.substring(path.lastIndexOf('.'));
 	var name = path.substring(path.lastIndexOf('\\')+1, path.lastIndexOf('.')) + suffix + extension;
+	if(opt.flattenDirectories === false){
+		name = path.substring(0, path.lastIndexOf('.')) + suffix + extension;
+		base = file.base;
+		cwd = file.cwd;
+	}
 	
 	if(!opt.width && !opt.height) { //no resizing to be done
 		return new gutil.File({
 			path: name,
+			base: base,
 			contents: file.contents
 		})
 	}
@@ -36,6 +44,7 @@ function goGoGadgetImageResize (file, opt) {
 				if(opt.upscale === false){
 					resolve(new gutil.File({
 						path: name,
+						base: base,
 						contents: file.contents
 					}));
 					return;
@@ -52,7 +61,7 @@ function goGoGadgetImageResize (file, opt) {
 					width = opt.width;
 				}
 			}
-
+			
 			if (opt.height){
 				if (/%$/.test(opt.height)) {
 					height = image.bitmap.height / 100 * parseFloat(opt.height);
@@ -65,7 +74,7 @@ function goGoGadgetImageResize (file, opt) {
 			image.resize(width, height).quality(100);
 			
 			var mime;
-			switch(extension.toLowerCase()){
+			switch(file.extname.toLowerCase()){
 				case ".jpg":
 				case ".jpeg":
 				case ".jpe":
@@ -87,6 +96,7 @@ function goGoGadgetImageResize (file, opt) {
 				
 				resolve(new gutil.File({
 					path: name,
+					base: base,
 					contents:buffer
 				}));
 			});

--- a/resize.js
+++ b/resize.js
@@ -5,34 +5,34 @@ var File = require('vinyl');
 const PLUGIN_NAME = "gulp-jimp-resize";
 
 function goGoGadgetImageResize (file, opt) {
-
+	
 	var path = file.path;
-
+	
 	var suffix = "";
-
+	
 	if(opt.suffix) { var suffix = "-" + opt.suffix; }
 	
 	var extension = path.substring(path.lastIndexOf('.'));
 	var name = path.substring(path.lastIndexOf('\\')+1, path.lastIndexOf('.')) + suffix + extension;
-
+	
 	if(!opt.width && !opt.height) { //no resizing to be done
 		return new gutil.File({
 			path: name,
 			contents: file.contents
 		})
 	}
-
+	
 	var result = new Promise(function(resolve, reject) {
 		Jimp.read(file.contents, function (err, image) {
 			if (err) {
 				reject(err);
 				return;
 			}
-
+			
 			var width = Jimp.AUTO; var height = Jimp.AUTO;
-
+			
 			if((opt.width && opt.width > image.bitmap.width) || 
-			   (opt.height && opt.height > image.bitmap.height)) {
+			(opt.height && opt.height > image.bitmap.height)) {
 				if(opt.upscale === false){
 					resolve(new gutil.File({
 						path: name,
@@ -43,42 +43,56 @@ function goGoGadgetImageResize (file, opt) {
 					gutil.log(PLUGIN_NAME, 'You are resizing an image to a larger size than the original');
 				}
 			}
+			
+			if (opt.width){
+				if (/%$/.test(opt.width)) {
+					width = image.bitmap.width / 100 * parseFloat(opt.width);
+				}
+				else {
+					width = opt.width;
+				}
+			}
 
-			if(opt.width) { width = opt.width; }
-
-			if(opt.height) { height = opt.height; }
+			if (opt.height){
+				if (/%$/.test(opt.height)) {
+					height = image.bitmap.height / 100 * parseFloat(opt.height);
+				}
+				else {
+					height = opt.height;
+				}
+			}
 			
 			image.resize(width, height).quality(100);
-        	
+			
 			var mime;
 			switch(extension.toLowerCase()){
 				case ".jpg":
 				case ".jpeg":
 				case ".jpe":
-					mime = Jimp.MIME_JPEG;
-					break;
+				mime = Jimp.MIME_JPEG;
+				break;
 				case ".png":
-					mime = Jimp.MIME_PNG;
-					break;
+				mime = Jimp.MIME_PNG;
+				break;
 				case ".bmp":
 				case ".dib":
-					mime = Jimp.MIME_BMP;
-					break;
+				mime = Jimp.MIME_BMP;
+				break;
 			}
-	       	var newImg = image.getBuffer(mime, function(err, buffer){
+			var newImg = image.getBuffer(mime, function(err, buffer){
 				if (err) {
 					reject(err);
 					return;
 				}
-
-	       		resolve(new gutil.File({
-	       			path: name,
-	       			contents:buffer
-	       		}));
-	        });
+				
+				resolve(new gutil.File({
+					path: name,
+					contents:buffer
+				}));
+			});
 		});
 	})
-
+	
 	return result;
 };
 

--- a/resize.js
+++ b/resize.js
@@ -1,14 +1,14 @@
 var Jimp = require("jimp");
-var gutil = require('gulp-util');
 var File = require('vinyl');
+var log = require('fancy-log');
 
 const PLUGIN_NAME = "gulp-jimp-resize";
 
 function goGoGadgetImageResize (file, opt) {
 	
 	var path = file.path;
-	var base = "";
-	var cwd = "";
+	var base;
+	var cwd;
 	
 	var suffix = "";
 	
@@ -23,7 +23,7 @@ function goGoGadgetImageResize (file, opt) {
 	}
 	
 	if(!opt.width && !opt.height) { //no resizing to be done
-		return new gutil.File({
+		return new File({
 			path: name,
 			base: base,
 			contents: file.contents
@@ -42,14 +42,14 @@ function goGoGadgetImageResize (file, opt) {
 			if((opt.width && opt.width > image.bitmap.width) || 
 			(opt.height && opt.height > image.bitmap.height)) {
 				if(opt.upscale === false){
-					resolve(new gutil.File({
+					resolve(new File({
 						path: name,
 						base: base,
 						contents: file.contents
 					}));
 					return;
 				}else{
-					gutil.log(PLUGIN_NAME, 'You are resizing an image to a larger size than the original');
+					log(PLUGIN_NAME, 'You are resizing an image to a larger size than the original');
 				}
 			}
 			
@@ -94,7 +94,7 @@ function goGoGadgetImageResize (file, opt) {
 					return;
 				}
 				
-				resolve(new gutil.File({
+				resolve(new File({
 					path: name,
 					base: base,
 					contents:buffer

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,6 @@
 var expect = require('chai').expect;
-var assert = require('chai').assert;
-var gulp = require('gulp');
 var File = require('vinyl');
 var fs = require('fs');
-var gutil = require('gulp-util');
 var Jimp = require('jimp');
 
 var plugin = require('../index');
@@ -38,24 +35,24 @@ function readImage(contents){
 	});
 }
 
-var testImage = new gutil.File({
+var testImage = new File({
 	path: __dirname + '/originals/trees.jpg',
 	contents: fs.readFileSync( __dirname + '/originals/trees.jpg'),
 	mime: "image/jpg"
 })
 
-var testImage2 = new gutil.File({
+var testImage2 = new File({
 	path: __dirname + '/originals/portrait.png',
 	contents: fs.readFileSync( __dirname + '/originals/portrait.png'),
 	mime: "image/png"
 })
 
-var testText= new gutil.File({
+var testText= new File({
 	path: __dirname + '/originals/test.txt',
 	contents: fs.readFileSync( __dirname + '/originals/test.txt')
 })
 
-var testGif= new gutil.File({
+var testGif= new File({
 	path: __dirname + '/originals/haha.gif',
 	contents: fs.readFileSync( __dirname + '/originals/haha.gif')
 })


### PR DESCRIPTION
If a width of height ends with a percent symbol (%), it gets correctly resized to that percentage.

Additionally, I've fixed an issue with relative pathing.